### PR TITLE
Add external access deployment

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,7 +1,6 @@
 server {
     listen       80;
     listen  [::]:80;
-    server_name  localhost;
 
     location / {
         root   /app;


### PR DESCRIPTION
Added deployment with external access

Container without mounting another nginx.conf did not allow access to the interface from the network