### PR TITLE
added persistent database volume in default docker compose

### DIFF
--- a/deployment.sh
+++ b/deployment.sh
@@ -68,13 +68,14 @@ fi
 
 echo "Downloading configuration files..."
 
-sudo curl -L "https://raw.githubusercontent.com/WongSaang/chatgpt-ui/main/docker-compose.yml" -o docker-compose.yml
-
-echo "Pulling images..."
-
-sudo docker-compose pull
+# if docker-compose.yml doesn't exist, download it
+if [ ! -f "docker-compose.yml" ]; then
+    sudo curl -L "https://raw.githubusercontent.com/WongSaang/chatgpt-ui/main/docker-compose.yml" -o docker-compose.yml
+fi
 
 echo "Starting services..."
+
+touch ./db_sqlite3/db.sqlite3
 
 sudo APP_DOMAIN="${APP_DOMAIN}:${SERVER_PORT}" CLIENT_PORT=${CLIENT_PORT} SERVER_PORT=${SERVER_PORT} WSGI_PORT=${WSGI_PORT} DB_URL=${DATABASE_URL}  docker-compose up -d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
 #      - EMAIL_HOST_PASSWORD=
 #      - EMAIL_USE_TLS=True
 #      - EMAIL_FROM=no-reply@example.com  #Default sender email address
+    volumes:
+      - db_sqlite3:/app/db.sqlite3
     ports:
       - '${WSGI_PORT:-8000}:8000'
     networks:


### PR DESCRIPTION
After a week of trying to get the persistent storage to work, I finally found a way.
This change simply adds a volume in the docker compose.

```yaml
   volumes:
     - ./db_sqlite3/db.sqlite3:/app/db.sqlite3
  ```

it's also necessary to create the db.sqlite3 file, that's why I added `touch ./db_sqlite3/db.sqlite3` in the deployment.sh

You might also want to mention that in the README.md (the `touch` part)

please make this the default, I keep seeing so many issues in this repository of people asking how to make it work, I hope this helps

and have a good day