### PR TITLE
fix db_sqlite3 path error in docker-compose problem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 #      - EMAIL_USE_TLS=True
 #      - EMAIL_FROM=no-reply@example.com  #Default sender email address
     volumes:
-      - ./db_sqlite3:/app/db.sqlite3
+      - ./db.sqlite3:/app/db.sqlite3
     ports:
       - '${WSGI_PORT:-8000}:8000'
     networks:


### PR DESCRIPTION
Since the db.sqlite3 file add into the repo, the docker-compose will emit can't find db_sqlite3 error, it cause the typo error of the db_sqlite3, it should be the db.sqlite3