### PR TITLE
fix: route not found when verify e-mail

### DIFF
--- a/pages/account/verify-email.vue
+++ b/pages/account/verify-email.vue
@@ -68,7 +68,7 @@ onNuxtReady(() => {
         <v-btn
             color="primary"
             variant="text"
-            @click="navigateTo('/account/login')"
+            @click="navigateTo('/account/signin')"
         >
           Sign in
         </v-btn>

--- a/pages/account/verify-email.vue
+++ b/pages/account/verify-email.vue
@@ -10,7 +10,7 @@ const status = ref('')
 
 const verifyEmail = async () => {
   verifying.value = true
-  const { data, error } = await useFetch(`/api/account/registration/verify-email/`, {
+  const { data, error } = await useFetch(`/api/account/verify-email/`, {
     method: 'POST',
     body: JSON.stringify({
       key: route.params.token


### PR DESCRIPTION
- route not found when access the confirm link
verify email API in front is `/api/account/registration/verify-email/`
but the route in [chatgpt-ui-server](https://github.com/WongSaang/chatgpt-ui-server/blob/main/account/urls.py) is: 
    ```
    urlpatterns = [https://github.com/WongSaang/chatgpt-ui/pull/244/commits
        path('', include('dj_rest_auth.urls')),
        path('registration/', RegistrationView.as_view(), name='rest_register'),
        path('verify-email/', VerifyEmailView.as_view(), name='rest_verify_email'),
        path('resend-email/', ResendEmailVerificationView.as_view(), name="rest_resend_email"),
    ```

- page not found when click the "Sign in" button on email verify page
navigate URL is `navigateTo('/account/login')` but the page does not exists.