### PR TITLE
prevent enter key from interrupting input method

### DIFF
--- a/components/MsgEditor.vue
+++ b/components/MsgEditor.vue
@@ -152,7 +152,7 @@ const docDialogCtl = ref({
         clearable
         variant="outlined"
         class="userinputmsg"
-        @keydown.enter.exact="enterOnly"
+        @keypress.enter.exact="enterOnly"
     ></v-textarea>
     <v-btn
         :disabled="loading"


### PR DESCRIPTION
Use keypress event instead of keydown event on the textarea